### PR TITLE
Link against CGAL::CGAL  and  Eigen3::Eigen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories( ${LIBIGL_INCLUDE})
 # Get Eigen3
 find_package(Eigen3 REQUIRED)
 if (Eigen3_FOUND)
-    message(STATUS "${EIGEN3_VERSION_STRING}")
+    message(STATUS "${EIGEN3_VERSION_STRING} FOUND")
     # include_directories(${EIGEN3_INCLUDE_DIR})
 endif ()
 
@@ -38,7 +38,7 @@ endif ()
 # Get CGAL
 find_package(CGAL REQUIRED)
 if (CGAL_FOUND)
-   #  include(${CGAL_USE_FILE})
+    message(STATUS "CGAL FOUND")
 else ()
     message("ERROR: this program requires CGAL and will not be compiled.")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.17)
-set(CMAKE_TOOLCHAIN_FILE C:/dev/vcpkg/scripts/buildsystems/vcpkg.cmake)
+# set(CMAKE_TOOLCHAIN_FILE C:/dev/vcpkg/scripts/buildsystems/vcpkg.cmake)
 project(BGAL)
 
 
 # Default Build_type RELEASE
 set(CMAKE_BUILD_TYPE RELEASE)
 # CXX STANDARD
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 # Set Version
 set(VERSION 1.0)
 # Set lib output directory
@@ -18,24 +18,27 @@ option(CMAKE_INSTALL_PREFIX "BGAL install PATH" /usr/local)
 # include header from project_source_dir
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
+find_path( LIBIGL_INCLUDE "igl/ZERO.h")
+include_directories( ${LIBIGL_INCLUDE})
+
 # Get Eigen3
 find_package(Eigen3 REQUIRED)
 if (Eigen3_FOUND)
     message(STATUS "${EIGEN3_VERSION_STRING}")
-    include_directories(${EIGEN3_INCLUDE_DIR})
+    # include_directories(${EIGEN3_INCLUDE_DIR})
 endif ()
 
 # Get Boost
 find_package(Boost REQUIRED)
 if (Boost_FOUND)
-    message(STATUS "BOOST FOUNDED")
+    message(STATUS "BOOST FOUND")
     include_directories(${Boost_INCLUDE_DIRS})
 endif ()
 
 # Get CGAL
 find_package(CGAL REQUIRED)
 if (CGAL_FOUND)
-    include(${CGAL_USE_FILE})
+   #  include(${CGAL_USE_FILE})
 else ()
     message("ERROR: this program requires CGAL and will not be compiled.")
 endif ()
@@ -66,7 +69,7 @@ install(TARGETS Algorithm BaseShape Draw Geodesic Integral Model Optimization Po
 	ARCHIVE DESTINATION lib
 	RUNTIME DESTINATION bin
 	PUBLIC_HEADER DESTINATION include
-	)	
+	)
 install(DIRECTORY ./include/ DESTINATION include
         FILES_MATCHING PATTERN "*.h")
 configure_file(${PROJECT_NAME}-config.cmake.in ${PROJECT_NAME}-config.cmake @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ include_directories( ${LIBIGL_INCLUDE})
 find_package(Eigen3 REQUIRED)
 if (Eigen3_FOUND)
     message(STATUS "${EIGEN3_VERSION_STRING} FOUND")
-    # include_directories(${EIGEN3_INCLUDE_DIR})
 endif ()
 
 # Get Boost

--- a/src/BaseShape/CMakeLists.txt
+++ b/src/BaseShape/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.17)
 
-set(BGAL_BaseShape_SRC        
+set(BGAL_BaseShape_SRC
         KDTree.cpp
         Line.cpp
         Point.cpp
@@ -17,3 +17,6 @@ set_target_properties(BaseShape PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 target_include_directories(BaseShape PUBLIC
 	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 	$<INSTALL_INTERFACE:include>)
+
+
+target_link_libraries (BaseShape CGAL::CGAL Eigen3::Eigen)

--- a/src/CVTLike/CMakeLists.txt
+++ b/src/CVTLike/CMakeLists.txt
@@ -1,13 +1,13 @@
 cmake_minimum_required(VERSION 3.17)
 
-set(BGAL_CVTLike_SRC        
+set(BGAL_CVTLike_SRC
 		CPD.cpp
 		CVT.cpp
 		)
 # Get static lib
 find_package(OpenMP REQUIRED)
 add_library(CVTLike STATIC ${BGAL_CVTLike_SRC})
-target_link_libraries(CVTLike Algorithm BaseShape Model Tessellation2D Tessellation3D Optimization OpenMP::OpenMP_CXX ${Boost_LIBRARIES})
+target_link_libraries(CVTLike Algorithm BaseShape Model Tessellation2D Tessellation3D Optimization OpenMP::OpenMP_CXX CGAL::CGAL ${Boost_LIBRARIES})
 set_target_properties(CVTLike PROPERTIES VERSION ${VERSION})
 set_target_properties(CVTLike PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 

--- a/src/Optimization/CMakeLists.txt
+++ b/src/Optimization/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.17)
 
-set(BGAL_Optimization_SRC        
+set(BGAL_Optimization_SRC
         ALGLIB/alglibinternal.cpp
         ALGLIB/alglibmisc.cpp
         ALGLIB/ap.cpp
@@ -27,3 +27,5 @@ set_target_properties(Optimization PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 target_include_directories(Optimization PUBLIC
 	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 	$<INSTALL_INTERFACE:include>)
+
+target_link_libraries (Optimization Eigen3::Eigen)


### PR DESCRIPTION
I would like to suggest some changes in the `CMakeLists.txt` files.

`include(${CGAL_USE_FILE})`   is no longer supported when using `CGAL 6.0`.    Instead we add `CGAL::CGAL` to  `target_link_libraries()`.    

We do the same for linking against  `Eigen3::Eigen`

For `libigl`  I  added a `find_path()`

I changed the cxx standard as we use `<filesystem>`

I commented setting `CMAKE_TOOLCHAIN_FILE`. Maybe that explains why I have to provide a path for `libigl` etc,?
